### PR TITLE
Gradle build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.class
+.gradle
 
 # Package Files #
 *.jar

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Examples of usage
 ======
 Set namespace:
 ```
-> namespace "-GLOBAL-";
+> namespace -GLOBAL-;
 namespace is now "-GLOBAL-"
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ Known issues
 How to install
 ======
 ```
+# build
 gradle installDist
+
+# run
 ./build/install/gaecl/bin/gaeshell --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Known issues
 ======
 [Application-specific password](https://support.google.com/accounts/answer/185833) should be used in case of 2-step verification on google account. Otherwise LoginException with reason "BadAuthentication InvalidSecondFactor" will be thrown.
 
+How to install
+======
+```
+gradle installDist
+./build/install/gaecl/bin/gaeshell --help
+```
+
 Examples of usage
 ======
 Set namespace:
@@ -103,8 +110,3 @@ Complete list of supported ​data types:
 * User
 * List
 * StringList
-
-Build dependencies
-===
-- commons-cli-1.2
-- commons-io-2.4

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,43 @@
+apply plugin: 'java'
+apply plugin: 'application'
+
+ext {
+    appengineSdkVersion = '1.9.42'
+}
+
+compileJava {
+    sourceCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_7
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile group: 'commons-io', name: 'commons-io', version: '2.4'
+    compile group: 'commons-cli', name: 'commons-cli', version: '1.2'
+    compile group: 'com.google.appengine', name: 'appengine-api-1.0-sdk', version: "${appengineSdkVersion}"
+    compile group: 'com.google.appengine', name: 'appengine-remote-api', version: "${appengineSdkVersion}"
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src'
+        }
+    }
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'com.inpun.alt.gaecl.AppEngineShell'
+    }
+    from configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+}
+
+mainClassName = 'com.inpun.alt.gaecl.AppEngineShell'
+
+startScripts {
+    applicationName = 'gaeshell'
+}


### PR DESCRIPTION
I added `build.gradle` to the project for building by Gradle.
By using this, there is no need for users to pre-install dependent libraries and customize class path.

``` sh
# build
gradle installDist

# run
./build/install/gaecl/bin/gaeshell --help
```
